### PR TITLE
Add self-hosted deployment workflow with Tailscale

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,11 +10,11 @@ jobs:
   deploy:
     name: Deploy via Docker Compose
     runs-on: self-hosted
-    
+
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
-      
+
       - name: Create .env file from secrets
         run: |
           cat > .env << EOF
@@ -23,19 +23,19 @@ jobs:
           RATMAS_ROLE_ID=${{ secrets.RATMAS_ROLE_ID }}
           DATABASE_URL=${{ secrets.DATABASE_URL }}
           EOF
-      
+
       - name: Pull Docker images
         run: docker-compose pull
-      
+
       - name: Stop existing containers
         run: docker-compose down
-      
+
       - name: Start services
         run: docker-compose up -d
-      
+
       - name: Clean up old images
         run: docker image prune -f
-      
+
       - name: Check service health
         run: |
           echo "Waiting for service to be ready..."

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,25 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Validate required secrets
+        run: |
+          if [ -z "${{ secrets.DISCORD_TOKEN }}" ]; then
+            echo "Error: DISCORD_TOKEN secret is not set"
+            exit 1
+          fi
+          if [ -z "${{ secrets.DISCORD_CLIENT_ID }}" ]; then
+            echo "Error: DISCORD_CLIENT_ID secret is not set"
+            exit 1
+          fi
+          if [ -z "${{ secrets.RATMAS_ROLE_ID }}" ]; then
+            echo "Error: RATMAS_ROLE_ID secret is not set"
+            exit 1
+          fi
+          if [ -z "${{ secrets.DATABASE_URL }}" ]; then
+            echo "Error: DATABASE_URL secret is not set"
+            exit 1
+          fi
+
       - name: Create .env file from secrets
         run: |
           cat > .env << EOF
@@ -23,15 +42,16 @@ jobs:
           RATMAS_ROLE_ID=${{ secrets.RATMAS_ROLE_ID }}
           DATABASE_URL=${{ secrets.DATABASE_URL }}
           EOF
+          chmod 600 .env
 
       - name: Pull Docker images
-        run: docker-compose pull
+        run: docker compose pull
 
       - name: Stop existing containers
-        run: docker-compose down
+        run: docker compose down
 
       - name: Start services
-        run: docker-compose up -d
+        run: docker compose up -d
 
       - name: Clean up old images
         run: docker image prune -f
@@ -40,5 +60,5 @@ jobs:
         run: |
           echo "Waiting for service to be ready..."
           sleep 10
-          docker-compose ps
-          docker-compose logs --tail=50
+          docker compose ps
+          docker compose logs --tail=50

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,44 @@
+name: Deploy to Server
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch: # Allows manual triggering from GitHub UI
+
+jobs:
+  deploy:
+    name: Deploy via Docker Compose
+    runs-on: self-hosted
+    
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+      
+      - name: Create .env file from secrets
+        run: |
+          cat > .env << EOF
+          DISCORD_TOKEN=${{ secrets.DISCORD_TOKEN }}
+          DISCORD_CLIENT_ID=${{ secrets.DISCORD_CLIENT_ID }}
+          RATMAS_ROLE_ID=${{ secrets.RATMAS_ROLE_ID }}
+          DATABASE_URL=${{ secrets.DATABASE_URL }}
+          EOF
+      
+      - name: Pull Docker images
+        run: docker-compose pull
+      
+      - name: Stop existing containers
+        run: docker-compose down
+      
+      - name: Start services
+        run: docker-compose up -d
+      
+      - name: Clean up old images
+        run: docker image prune -f
+      
+      - name: Check service health
+        run: |
+          echo "Waiting for service to be ready..."
+          sleep 10
+          docker-compose ps
+          docker-compose logs --tail=50

--- a/docs/DEPLOYMENT_SETUP.md
+++ b/docs/DEPLOYMENT_SETUP.md
@@ -120,8 +120,9 @@ Your workflow needs these secrets to create the `.env` file for your bot. Add th
    ```
 
 4. Test Docker Compose:
+
    ```bash
-   docker-compose version
+   docker compose version
    ```
 
 ## Step 5: Test the Deployment
@@ -134,9 +135,10 @@ Your workflow needs these secrets to create the `.env` file for your bot. Add th
 2. Monitor the workflow execution in the GitHub Actions UI
 
 3. On your server, verify the bot is running:
+
    ```bash
-   docker-compose ps
-   docker-compose logs -f
+   docker compose ps
+   docker compose logs -f
    ```
 
 ## Troubleshooting
@@ -193,7 +195,7 @@ If you need to deploy manually:
 ```bash
 cd ~/ratmas-bot
 git pull origin main
-docker-compose pull
-docker-compose down
-docker-compose up -d
+docker compose pull
+docker compose down
+docker compose up -d
 ```

--- a/docs/DEPLOYMENT_SETUP.md
+++ b/docs/DEPLOYMENT_SETUP.md
@@ -1,0 +1,186 @@
+# Deployment Setup Guide
+
+This guide walks you through setting up secure, automatic deployment for the Ratmas bot using Tailscale and a self-hosted GitHub Actions runner.
+
+## Overview
+
+The deployment workflow:
+- Runs on a self-hosted runner on your server (no SSH ports exposed to the internet)
+- Uses Tailscale for secure networking
+- Deploys via Docker Compose on every push to `main`
+
+## Prerequisites
+
+- A server running Linux (Ubuntu, Debian, etc.)
+- Docker and Docker Compose installed
+- Admin access to the GitHub repository
+
+## Step 1: Install Tailscale on Your Server
+
+1. SSH into your server (however you currently access it)
+
+2. Install Tailscale:
+   ```bash
+   curl -fsSL https://tailscale.com/install.sh | sh
+   ```
+
+3. Start Tailscale and authenticate:
+   ```bash
+   sudo tailscale up
+   ```
+   
+4. Open the URL in your browser and authenticate with your Tailscale account
+
+5. Verify installation:
+   ```bash
+   tailscale status
+   ```
+   
+   Note your server's Tailscale IP (e.g., `100.x.x.x`) and MagicDNS name.
+
+## Step 2: Set Up GitHub Actions Self-Hosted Runner
+
+1. On GitHub, go to your repository: **Settings → Actions → Runners → New self-hosted runner**
+
+2. Select **Linux** as the operating system
+
+3. On your server, create a directory for the runner:
+   ```bash
+   mkdir -p ~/actions-runner && cd ~/actions-runner
+   ```
+
+4. Download the runner (use the exact commands provided by GitHub, but here's an example):
+   ```bash
+   curl -o actions-runner-linux-x64-2.316.0.tar.gz -L \
+     https://github.com/actions/runner/releases/download/v2.316.0/actions-runner-linux-x64-2.316.0.tar.gz
+   tar xzf ./actions-runner-linux-x64-2.316.0.tar.gz
+   ```
+
+5. Configure the runner (replace `<TOKEN>` with the token from GitHub):
+   ```bash
+   ./config.sh --url https://github.com/andrewgari/ratmas-bot --token <TOKEN>
+   ```
+   
+   When prompted:
+   - Runner group: Press Enter (default)
+   - Runner name: Press Enter (or choose a name like "ratmas-server")
+   - Work folder: Press Enter (default)
+   - Labels: Press Enter (default)
+
+6. **Option A: Run the runner interactively (for testing)**
+   ```bash
+   ./run.sh
+   ```
+
+7. **Option B: Install as a service (recommended for production)**
+   ```bash
+   sudo ./svc.sh install
+   sudo ./svc.sh start
+   sudo ./svc.sh status
+   ```
+
+## Step 3: Configure GitHub Secrets
+
+Your workflow needs these secrets to create the `.env` file for your bot. Add them in GitHub:
+
+1. Go to **Settings → Secrets and variables → Actions → New repository secret**
+
+2. Add the following secrets:
+   - `DISCORD_TOKEN` - Your Discord bot token
+   - `DISCORD_CLIENT_ID` - Your Discord application client ID
+   - `RATMAS_ROLE_ID` - The role ID for Ratmas participants
+   - `DATABASE_URL` - The database connection string (e.g., `file:/app/data/ratmas.sqlite`)
+
+## Step 4: Prepare Your Server Environment
+
+1. Clone the repository on your server (if not already done):
+   ```bash
+   cd ~
+   git clone https://github.com/andrewgari/ratmas-bot.git
+   cd ratmas-bot
+   ```
+
+2. Create the data directory for the SQLite database:
+   ```bash
+   mkdir -p data
+   ```
+
+3. Ensure Docker is running:
+   ```bash
+   sudo systemctl status docker
+   ```
+
+4. Test Docker Compose:
+   ```bash
+   docker-compose version
+   ```
+
+## Step 5: Test the Deployment
+
+1. Push a commit to the `main` branch, or manually trigger the workflow:
+   - Go to **Actions** tab in GitHub
+   - Click **Deploy to Server**
+   - Click **Run workflow**
+
+2. Monitor the workflow execution in the GitHub Actions UI
+
+3. On your server, verify the bot is running:
+   ```bash
+   docker-compose ps
+   docker-compose logs -f
+   ```
+
+## Troubleshooting
+
+### Runner not showing as online
+- Check the runner service: `sudo ./svc.sh status`
+- View runner logs: `journalctl -u actions.runner.andrewgari-ratmas-bot.*`
+
+### Docker permission denied
+- Add the runner user to the docker group:
+  ```bash
+  sudo usermod -aG docker $USER
+  ```
+- Restart the runner service
+
+### Secrets not loading
+- Verify secrets are set in GitHub Settings → Secrets and variables → Actions
+- Check the workflow logs for specific error messages
+
+### Container fails to start
+- Check logs: `docker-compose logs`
+- Verify the `.env` file was created: `cat .env`
+- Ensure the database directory exists: `ls -la data/`
+
+## Security Notes
+
+- Port 22 (SSH) does not need to be exposed to the internet
+- The runner operates within your private Tailscale network
+- Secrets are never logged or exposed in GitHub Actions
+- The `.env` file is recreated on each deployment and never committed to git
+
+## Updating the Runner
+
+GitHub occasionally releases new runner versions. To update:
+
+```bash
+cd ~/actions-runner
+./svc.sh stop
+./svc.sh uninstall
+# Download and extract the new version
+./config.sh --url https://github.com/andrewgari/ratmas-bot --token <NEW_TOKEN>
+./svc.sh install
+./svc.sh start
+```
+
+## Manual Deployment (Without Workflow)
+
+If you need to deploy manually:
+
+```bash
+cd ~/ratmas-bot
+git pull origin main
+docker-compose pull
+docker-compose down
+docker-compose up -d
+```

--- a/docs/DEPLOYMENT_SETUP.md
+++ b/docs/DEPLOYMENT_SETUP.md
@@ -5,6 +5,7 @@ This guide walks you through setting up secure, automatic deployment for the Rat
 ## Overview
 
 The deployment workflow:
+
 - Runs on a self-hosted runner on your server (no SSH ports exposed to the internet)
 - Uses Tailscale for secure networking
 - Deploys via Docker Compose on every push to `main`
@@ -20,6 +21,7 @@ The deployment workflow:
 1. SSH into your server (however you currently access it)
 
 2. Install Tailscale:
+
    ```bash
    curl -fsSL https://tailscale.com/install.sh | sh
    ```
@@ -28,14 +30,14 @@ The deployment workflow:
    ```bash
    sudo tailscale up
    ```
-   
 4. Open the URL in your browser and authenticate with your Tailscale account
 
 5. Verify installation:
+
    ```bash
    tailscale status
    ```
-   
+
    Note your server's Tailscale IP (e.g., `100.x.x.x`) and MagicDNS name.
 
 ## Step 2: Set Up GitHub Actions Self-Hosted Runner
@@ -45,11 +47,13 @@ The deployment workflow:
 2. Select **Linux** as the operating system
 
 3. On your server, create a directory for the runner:
+
    ```bash
    mkdir -p ~/actions-runner && cd ~/actions-runner
    ```
 
 4. Download the runner (use the exact commands provided by GitHub, but here's an example):
+
    ```bash
    curl -o actions-runner-linux-x64-2.316.0.tar.gz -L \
      https://github.com/actions/runner/releases/download/v2.316.0/actions-runner-linux-x64-2.316.0.tar.gz
@@ -57,10 +61,11 @@ The deployment workflow:
    ```
 
 5. Configure the runner (replace `<TOKEN>` with the token from GitHub):
+
    ```bash
    ./config.sh --url https://github.com/andrewgari/ratmas-bot --token <TOKEN>
    ```
-   
+
    When prompted:
    - Runner group: Press Enter (default)
    - Runner name: Press Enter (or choose a name like "ratmas-server")
@@ -68,6 +73,7 @@ The deployment workflow:
    - Labels: Press Enter (default)
 
 6. **Option A: Run the runner interactively (for testing)**
+
    ```bash
    ./run.sh
    ```
@@ -94,6 +100,7 @@ Your workflow needs these secrets to create the `.env` file for your bot. Add th
 ## Step 4: Prepare Your Server Environment
 
 1. Clone the repository on your server (if not already done):
+
    ```bash
    cd ~
    git clone https://github.com/andrewgari/ratmas-bot.git
@@ -101,11 +108,13 @@ Your workflow needs these secrets to create the `.env` file for your bot. Add th
    ```
 
 2. Create the data directory for the SQLite database:
+
    ```bash
    mkdir -p data
    ```
 
 3. Ensure Docker is running:
+
    ```bash
    sudo systemctl status docker
    ```
@@ -133,10 +142,12 @@ Your workflow needs these secrets to create the `.env` file for your bot. Add th
 ## Troubleshooting
 
 ### Runner not showing as online
+
 - Check the runner service: `sudo ./svc.sh status`
 - View runner logs: `journalctl -u actions.runner.andrewgari-ratmas-bot.*`
 
 ### Docker permission denied
+
 - Add the runner user to the docker group:
   ```bash
   sudo usermod -aG docker $USER
@@ -144,10 +155,12 @@ Your workflow needs these secrets to create the `.env` file for your bot. Add th
 - Restart the runner service
 
 ### Secrets not loading
+
 - Verify secrets are set in GitHub Settings → Secrets and variables → Actions
 - Check the workflow logs for specific error messages
 
 ### Container fails to start
+
 - Check logs: `docker-compose logs`
 - Verify the `.env` file was created: `cat .env`
 - Ensure the database directory exists: `ls -la data/`

--- a/docs/DEPLOYMENT_SETUP.md
+++ b/docs/DEPLOYMENT_SETUP.md
@@ -163,7 +163,7 @@ Your workflow needs these secrets to create the `.env` file for your bot. Add th
 
 ### Container fails to start
 
-- Check logs: `docker-compose logs`
+- Check logs: `docker compose logs`
 - Verify the `.env` file was created: `cat .env`
 - Ensure the database directory exists: `ls -la data/`
 


### PR DESCRIPTION
## Summary

Adds a secure, self-hosted deployment workflow that uses Tailscale for networking and a GitHub Actions self-hosted runner for deployments. This approach avoids exposing SSH port 22 to the public internet.

## Changes

- **`.github/workflows/deploy.yml`**: New deployment workflow that:
  - Runs on self-hosted runner
  - Creates `.env` from GitHub secrets
  - Deploys via Docker Compose
  - Triggers on push to `main` or manual dispatch
  
- **`docs/DEPLOYMENT_SETUP.md`**: Comprehensive setup guide covering:
  - Tailscale installation and configuration
  - GitHub Actions self-hosted runner setup
  - GitHub secrets configuration
  - Troubleshooting and security notes

## Benefits

- ✅ No SSH ports exposed to the internet
- ✅ Secure networking via Tailscale VPN
- ✅ Automatic deployment on push to `main`
- ✅ Works with existing Docker Compose setup
- ✅ No cloud provider dependencies

## Testing

Follow the setup guide in `docs/DEPLOYMENT_SETUP.md` to configure:
1. Tailscale on your server
2. Self-hosted GitHub Actions runner
3. GitHub secrets for environment variables

Once configured, deployments will trigger automatically on merge to `main`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Automated deployment workflow now triggers on pushes to main branch and manual dispatch.

* **Documentation**
  * Added comprehensive Deployment Setup Guide with configuration instructions, security guidelines, troubleshooting steps, and manual deployment fallback procedures.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->