### PR TITLE
Replace modal with slash command options and add timezone support

### DIFF
--- a/__tests__/commands/ratmas-pairings.command.test.ts
+++ b/__tests__/commands/ratmas-pairings.command.test.ts
@@ -4,12 +4,12 @@ import {
   RATMAS_PAIRINGS_COMMAND,
 } from '../../src/commands/ratmas-pairings.command.js';
 import { RatService } from '../../src/services/rat.service.js';
-import { RatmasEventStatus } from '../../src/types/ratmas.types.js';
+import { RatmasEventStatus, RatmasEvent, PairingResult } from '../../src/types/ratmas.types.js';
 
 describe('ratmas-pairings command', () => {
   const ratServiceMocks = {
-    getActiveEvent: jest.fn<() => Promise<any>>(),
-    generatePairings: jest.fn<() => Promise<any>>(),
+    getActiveEvent: jest.fn<() => Promise<RatmasEvent | null>>(),
+    generatePairings: jest.fn<() => Promise<PairingResult>>(),
   };
 
   beforeEach(() => {

--- a/__tests__/commands/ratmas-start.command.test.ts
+++ b/__tests__/commands/ratmas-start.command.test.ts
@@ -2,9 +2,7 @@ import { describe, it, expect, beforeEach, jest } from '@jest/globals';
 import { ChannelType } from 'discord.js';
 import {
   handleRatmasStartCommand,
-  handleRatmasStartModal,
   RATMAS_COMMAND_NAME,
-  RATMAS_START_MODAL_ID,
 } from '../../src/commands/ratmas-start.command.js';
 import { RatService } from '../../src/services/rat.service.js';
 import { ChannelService } from '../../src/services/channel.service.js';
@@ -38,25 +36,7 @@ describe('ratmas-start command integration', () => {
     }));
   });
 
-  it('shows the schedule modal when the admin invokes /ratmas start', async () => {
-    const showModal = jest.fn();
-    const interaction = {
-      commandName: RATMAS_COMMAND_NAME,
-      options: { getSubcommand: () => 'start' },
-      memberPermissions: { has: () => true },
-      guildId: 'guild-123',
-      showModal,
-      client: {},
-    } as unknown as Parameters<typeof handleRatmasStartCommand>[0];
-
-    await handleRatmasStartCommand(interaction, deps);
-
-    expect(showModal).toHaveBeenCalledTimes(1);
-    const modal = showModal.mock.calls[0]?.[0] as { data?: { custom_id?: string } } | undefined;
-    expect(modal?.data?.custom_id).toBe(RATMAS_START_MODAL_ID);
-  });
-
-  it('runs the full modal flow and persists the event', async () => {
+  it('creates a Ratmas event when the admin invokes /ratmas start with date options', async () => {
     const send = jest.fn();
     channelServiceMocks.setChannelPermissions.mockImplementation(async () => ({ success: true }));
 
@@ -87,25 +67,28 @@ describe('ratmas-start command integration', () => {
       },
     };
 
-    const fieldValues: Record<string, string> = {
-      'ratmas-start-date': '2025-12-01',
-      'ratmas-end-date': '2025-12-26',
-      'ratmas-reveal-date': '2025-12-26',
-      'ratmas-purchase-deadline': '2025-12-16',
-    };
-
     const interaction = {
-      customId: RATMAS_START_MODAL_ID,
+      commandName: RATMAS_COMMAND_NAME,
+      options: {
+        getSubcommand: () => 'start',
+        getString: (name: string) => {
+          const values: Record<string, string> = {
+            timezone: 'UTC',
+            start_date: '2025-12-01',
+            end_date: '2025-12-26',
+            reveal_date: '2025-12-26',
+            purchase_deadline: '2025-12-16',
+          };
+          return values[name];
+        },
+      },
       guildId: 'guild-123',
       memberPermissions: { has: () => true },
       client,
-      fields: {
-        getTextInputValue: (id: string) => fieldValues[id],
-      },
       reply: jest.fn(),
-    } as unknown as Parameters<typeof handleRatmasStartModal>[0];
+    } as unknown as Parameters<typeof handleRatmasStartCommand>[0];
 
-    await handleRatmasStartModal(interaction, deps);
+    await handleRatmasStartCommand(interaction, deps);
 
     expect(channelServiceMocks.createTextChannel).toHaveBeenCalledWith('guild-123', {
       name: 'ratmas-2025',

--- a/__tests__/commands/ratmas-wishlist.command.test.ts
+++ b/__tests__/commands/ratmas-wishlist.command.test.ts
@@ -6,13 +6,13 @@ import {
   RATMAS_WISHLIST_MODAL_ID,
 } from '../../src/commands/ratmas-wishlist.command.js';
 import { RatService } from '../../src/services/rat.service.js';
-import { RatmasEventStatus } from '../../src/types/ratmas.types.js';
+import { RatmasEventStatus, RatmasEvent, RatmasParticipant } from '../../src/types/ratmas.types.js';
 
 describe('ratmas-wishlist command', () => {
   const ratServiceMocks = {
-    getActiveEvent: jest.fn<() => Promise<any>>(),
-    getOrCreateParticipant: jest.fn<() => Promise<any>>(),
-    updateParticipant: jest.fn<() => Promise<any>>(),
+    getActiveEvent: jest.fn<() => Promise<RatmasEvent | null>>(),
+    getOrCreateParticipant: jest.fn<() => Promise<RatmasParticipant>>(),
+    updateParticipant: jest.fn<() => Promise<RatmasParticipant>>(),
   };
 
   beforeEach(() => {

--- a/__tests__/utils/date.utils.test.ts
+++ b/__tests__/utils/date.utils.test.ts
@@ -196,7 +196,7 @@ describe('date.utils', () => {
     // Verify millisecond precision is maintained
     expect(schedule.eventEndDate.getMilliseconds()).toBe(999);
     expect(schedule.purchaseDeadline.getMilliseconds()).toBe(999);
-    
+
     // Verify exact time
     expect(schedule.eventEndDate.toISOString()).toBe('2025-12-01T23:59:59.999Z');
     expect(schedule.purchaseDeadline.toISOString()).toBe('2025-11-30T23:59:59.999Z');

--- a/__tests__/utils/date.utils.test.ts
+++ b/__tests__/utils/date.utils.test.ts
@@ -76,6 +76,172 @@ describe('date.utils', () => {
     ).toThrow('Start date must be in YYYY-MM-DD format');
   });
 
+  it('converts Europe/London timezone correctly (UTC+0/+1)', () => {
+    const schedule = parseRatmasSchedule({
+      startDate: '2025-12-01',
+      endDate: '2025-12-25',
+      revealDate: '2025-12-26',
+      purchaseDeadline: '2025-12-15',
+      timezone: 'Europe/London', // GMT is UTC+0
+    });
+
+    // 2025-12-01 00:00:00 GMT = 2025-12-01 00:00:00 UTC
+    expect(schedule.eventStartDate.toISOString()).toBe('2025-12-01T00:00:00.000Z');
+    // 2025-12-25 23:59:59.999 GMT = 2025-12-25 23:59:59.999 UTC
+    expect(schedule.eventEndDate.toISOString()).toBe('2025-12-25T23:59:59.999Z');
+    // 2025-12-26 00:00:00 GMT = 2025-12-26 00:00:00 UTC
+    expect(schedule.revealDate.toISOString()).toBe('2025-12-26T00:00:00.000Z');
+    // 2025-12-15 23:59:59.999 GMT = 2025-12-15 23:59:59.999 UTC
+    expect(schedule.purchaseDeadline.toISOString()).toBe('2025-12-15T23:59:59.999Z');
+  });
+
+  it('converts Asia/Tokyo timezone correctly (UTC+9)', () => {
+    const schedule = parseRatmasSchedule({
+      startDate: '2025-12-01',
+      endDate: '2025-12-25',
+      revealDate: '2025-12-26',
+      purchaseDeadline: '2025-12-15',
+      timezone: 'Asia/Tokyo', // JST is UTC+9
+    });
+
+    // 2025-12-01 00:00:00 JST = 2025-11-30 15:00:00 UTC
+    expect(schedule.eventStartDate.toISOString()).toBe('2025-11-30T15:00:00.000Z');
+    // 2025-12-25 23:59:59.999 JST = 2025-12-25 14:59:59.999 UTC
+    expect(schedule.eventEndDate.toISOString()).toBe('2025-12-25T14:59:59.999Z');
+    // 2025-12-26 00:00:00 JST = 2025-12-25 15:00:00 UTC
+    expect(schedule.revealDate.toISOString()).toBe('2025-12-25T15:00:00.000Z');
+    // 2025-12-15 23:59:59.999 JST = 2025-12-15 14:59:59.999 UTC
+    expect(schedule.purchaseDeadline.toISOString()).toBe('2025-12-15T14:59:59.999Z');
+  });
+
+  it('converts Australia/Sydney timezone correctly (UTC+10/+11)', () => {
+    const schedule = parseRatmasSchedule({
+      startDate: '2025-12-01',
+      endDate: '2025-12-25',
+      revealDate: '2025-12-26',
+      purchaseDeadline: '2025-12-15',
+      timezone: 'Australia/Sydney', // AEDT is UTC+11 in December
+    });
+
+    // 2025-12-01 00:00:00 AEDT = 2025-11-30 13:00:00 UTC (AEDT is UTC+11)
+    expect(schedule.eventStartDate.toISOString()).toBe('2025-11-30T13:00:00.000Z');
+    // 2025-12-25 23:59:59.999 AEDT = 2025-12-25 12:59:59.999 UTC
+    expect(schedule.eventEndDate.toISOString()).toBe('2025-12-25T12:59:59.999Z');
+    // 2025-12-26 00:00:00 AEDT = 2025-12-25 13:00:00 UTC
+    expect(schedule.revealDate.toISOString()).toBe('2025-12-25T13:00:00.000Z');
+    // 2025-12-15 23:59:59.999 AEDT = 2025-12-15 12:59:59.999 UTC
+    expect(schedule.purchaseDeadline.toISOString()).toBe('2025-12-15T12:59:59.999Z');
+  });
+
+  it('converts America/Los_Angeles timezone correctly (UTC-8/-7)', () => {
+    const schedule = parseRatmasSchedule({
+      startDate: '2025-12-01',
+      endDate: '2025-12-25',
+      revealDate: '2025-12-26',
+      purchaseDeadline: '2025-12-15',
+      timezone: 'America/Los_Angeles', // PST is UTC-8
+    });
+
+    // 2025-12-01 00:00:00 PST = 2025-12-01 08:00:00 UTC (PST is UTC-8)
+    expect(schedule.eventStartDate.toISOString()).toBe('2025-12-01T08:00:00.000Z');
+    // 2025-12-25 23:59:59.999 PST = 2025-12-26 07:59:59.999 UTC
+    expect(schedule.eventEndDate.toISOString()).toBe('2025-12-26T07:59:59.999Z');
+    // 2025-12-26 00:00:00 PST = 2025-12-26 08:00:00 UTC
+    expect(schedule.revealDate.toISOString()).toBe('2025-12-26T08:00:00.000Z');
+    // 2025-12-15 23:59:59.999 PST = 2025-12-16 07:59:59.999 UTC
+    expect(schedule.purchaseDeadline.toISOString()).toBe('2025-12-16T07:59:59.999Z');
+  });
+
+  it('handles date boundaries correctly with negative UTC offset', () => {
+    // Test that a date in PST properly crosses into the next day in UTC
+    const schedule = parseRatmasSchedule({
+      startDate: '2025-06-15',
+      endDate: '2025-06-15',
+      revealDate: '2025-06-16',
+      purchaseDeadline: '2025-06-14',
+      timezone: 'America/Los_Angeles', // PDT is UTC-7 in June
+    });
+
+    // Start of day: 2025-06-15 00:00:00 PDT = 2025-06-15 07:00:00 UTC
+    expect(schedule.eventStartDate.toISOString()).toBe('2025-06-15T07:00:00.000Z');
+    // End of day: 2025-06-15 23:59:59.999 PDT = 2025-06-16 06:59:59.999 UTC (crosses into next day)
+    expect(schedule.eventEndDate.toISOString()).toBe('2025-06-16T06:59:59.999Z');
+  });
+
+  it('handles date boundaries correctly with positive UTC offset', () => {
+    // Test that a date in JST properly crosses into the previous day in UTC
+    const schedule = parseRatmasSchedule({
+      startDate: '2025-06-15',
+      endDate: '2025-06-15',
+      revealDate: '2025-06-16',
+      purchaseDeadline: '2025-06-14',
+      timezone: 'Asia/Tokyo', // JST is UTC+9
+    });
+
+    // Start of day: 2025-06-15 00:00:00 JST = 2025-06-14 15:00:00 UTC (crosses into previous day)
+    expect(schedule.eventStartDate.toISOString()).toBe('2025-06-14T15:00:00.000Z');
+    // End of day: 2025-06-15 23:59:59.999 JST = 2025-06-15 14:59:59.999 UTC
+    expect(schedule.eventEndDate.toISOString()).toBe('2025-06-15T14:59:59.999Z');
+  });
+
+  it('preserves millisecond precision for end-of-day boundaries', () => {
+    const schedule = parseRatmasSchedule({
+      startDate: '2025-12-01',
+      endDate: '2025-12-01',
+      revealDate: '2025-12-02',
+      purchaseDeadline: '2025-11-30',
+      timezone: 'UTC',
+    });
+
+    // Verify millisecond precision is maintained
+    expect(schedule.eventEndDate.getMilliseconds()).toBe(999);
+    expect(schedule.purchaseDeadline.getMilliseconds()).toBe(999);
+    
+    // Verify exact time
+    expect(schedule.eventEndDate.toISOString()).toBe('2025-12-01T23:59:59.999Z');
+    expect(schedule.purchaseDeadline.toISOString()).toBe('2025-11-30T23:59:59.999Z');
+  });
+
+  it('handles DST transition dates correctly', () => {
+    // Test around DST transition in March for America/New_York
+    // DST starts March 9, 2025 at 2:00 AM (EDT begins, UTC-4)
+    const beforeDST = parseRatmasSchedule({
+      startDate: '2025-03-08',
+      endDate: '2025-03-08',
+      revealDate: '2025-03-09',
+      purchaseDeadline: '2025-03-07',
+      timezone: 'America/New_York',
+    });
+
+    const afterDST = parseRatmasSchedule({
+      startDate: '2025-03-10',
+      endDate: '2025-03-10',
+      revealDate: '2025-03-11',
+      purchaseDeadline: '2025-03-09',
+      timezone: 'America/New_York',
+    });
+
+    // Before DST: EST is UTC-5
+    expect(beforeDST.eventStartDate.toISOString()).toBe('2025-03-08T05:00:00.000Z');
+    // After DST: EDT is UTC-4
+    expect(afterDST.eventStartDate.toISOString()).toBe('2025-03-10T04:00:00.000Z');
+  });
+
+  it('correctly sequences dates across timezone conversions', () => {
+    const schedule = parseRatmasSchedule({
+      startDate: '2025-12-01',
+      endDate: '2025-12-26',
+      revealDate: '2025-12-26',
+      purchaseDeadline: '2025-12-16',
+      timezone: 'America/New_York',
+    });
+
+    // Verify logical ordering is maintained after UTC conversion
+    expect(schedule.eventStartDate.getTime()).toBeLessThan(schedule.purchaseDeadline.getTime());
+    expect(schedule.purchaseDeadline.getTime()).toBeLessThan(schedule.revealDate.getTime());
+    expect(schedule.revealDate.getTime()).toBeLessThanOrEqual(schedule.eventEndDate.getTime());
+  });
+
   it('formats dates as Discord timestamps', () => {
     const date = new Date('2025-12-01T00:00:00.000Z');
 

--- a/__tests__/utils/date.utils.test.ts
+++ b/__tests__/utils/date.utils.test.ts
@@ -12,12 +12,56 @@ describe('date.utils', () => {
       endDate: '2025-12-25',
       revealDate: '2025-12-26',
       purchaseDeadline: '2025-12-15',
+      timezone: 'UTC',
     });
 
     expect(schedule.eventStartDate.toISOString()).toBe('2025-12-01T00:00:00.000Z');
     expect(schedule.eventEndDate.toISOString()).toBe('2025-12-25T23:59:59.999Z');
     expect(schedule.revealDate.toISOString()).toBe('2025-12-26T00:00:00.000Z');
     expect(schedule.purchaseDeadline.toISOString()).toBe('2025-12-15T23:59:59.999Z');
+  });
+
+  it('converts timezone dates to UTC correctly', () => {
+    const schedule = parseRatmasSchedule({
+      startDate: '2025-12-01',
+      endDate: '2025-12-25',
+      revealDate: '2025-12-26',
+      purchaseDeadline: '2025-12-15',
+      timezone: 'America/New_York', // EST/EDT is UTC-5/-4
+    });
+
+    // 2025-12-01 00:00:00 EST = 2025-12-01 05:00:00 UTC (EST is UTC-5)
+    expect(schedule.eventStartDate.toISOString()).toBe('2025-12-01T05:00:00.000Z');
+    // 2025-12-25 23:59:59.999 EST = 2025-12-26 04:59:59.999 UTC
+    expect(schedule.eventEndDate.toISOString()).toBe('2025-12-26T04:59:59.999Z');
+    // 2025-12-26 00:00:00 EST = 2025-12-26 05:00:00 UTC
+    expect(schedule.revealDate.toISOString()).toBe('2025-12-26T05:00:00.000Z');
+    // 2025-12-15 23:59:59.999 EST = 2025-12-16 04:59:59.999 UTC
+    expect(schedule.purchaseDeadline.toISOString()).toBe('2025-12-16T04:59:59.999Z');
+  });
+
+  it('defaults to UTC when timezone is not provided', () => {
+    const schedule = parseRatmasSchedule({
+      startDate: '2025-12-01',
+      endDate: '2025-12-25',
+      revealDate: '2025-12-26',
+      purchaseDeadline: '2025-12-15',
+    });
+
+    expect(schedule.eventStartDate.toISOString()).toBe('2025-12-01T00:00:00.000Z');
+    expect(schedule.eventEndDate.toISOString()).toBe('2025-12-25T23:59:59.999Z');
+  });
+
+  it('throws when provided an invalid timezone', () => {
+    expect(() =>
+      parseRatmasSchedule({
+        startDate: '2025-12-01',
+        endDate: '2025-12-25',
+        revealDate: '2025-12-26',
+        purchaseDeadline: '2025-12-15',
+        timezone: 'Invalid/Timezone',
+      })
+    ).toThrow('Invalid timezone');
   });
 
   it('throws when provided an invalid date', () => {
@@ -27,6 +71,7 @@ describe('date.utils', () => {
         endDate: '2025-12-25',
         revealDate: '2025-12-26',
         purchaseDeadline: '2025-12-15',
+        timezone: 'UTC',
       })
     ).toThrow('Start date must be in YYYY-MM-DD format');
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -63,6 +63,7 @@
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -1814,6 +1815,7 @@
       "integrity": "sha512-BnOroVl1SgrPLywqxyqdJ4l3S2MsKVLDVxZvjI1Eoe8ev2r3kGDo+PcMihNmDE+6/KjkTubSJnmqGZZjQSBq/g==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.46.2",
         "@typescript-eslint/types": "8.46.2",
@@ -2029,6 +2031,7 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -2312,6 +2315,7 @@
         }
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.8.19",
         "caniuse-lite": "^1.0.30001751",
@@ -2735,6 +2739,7 @@
       "integrity": "sha512-t5aPOpmtJcZcz5UJyY2GbvpDlsK5E8JqRqoKtfiKE3cNh437KIqfJr3A3AKf5k64NPx6d0G3dno6XDY05PqPtw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -3626,6 +3631,7 @@
       "integrity": "sha512-NIy3oAFp9shda19hy4HK0HRTWKtPJmGdnvywu01nOqNC2vZg+Z+fvJDxpMQA88eb2I9EcafcdjYgsDthnYTvGw==",
       "dev": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^29.7.0",
         "@jest/types": "^29.6.3",
@@ -4868,6 +4874,7 @@
       "devOptional": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "@prisma/engines": "5.22.0"
       },
@@ -5463,6 +5470,7 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
+      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "test": "NODE_OPTIONS=--experimental-vm-modules jest",
     "test:watch": "NODE_OPTIONS=--experimental-vm-modules jest --watch",
     "test:coverage": "NODE_OPTIONS=--experimental-vm-modules jest --coverage",
-    "lint": "eslint ./src ./__tests__ --ext .ts",
+    "lint": "eslint ./src ./__tests__ --ext .ts --max-warnings=0",
     "lint:fix": "eslint ./src ./__tests__ --ext .ts --fix",
     "format": "prettier --write .",
     "format:check": "prettier --check .",

--- a/src/commands/ratmas-start.command.ts
+++ b/src/commands/ratmas-start.command.ts
@@ -2,7 +2,6 @@ import {
   ButtonInteraction,
   ChatInputCommandInteraction,
   Client,
-  ModalSubmitInteraction,
   PermissionFlagsBits,
   SlashCommandBuilder,
   SlashCommandSubcommandBuilder,
@@ -11,15 +10,10 @@ import {
 import { RatService } from '../services/rat.service.js';
 import { ChannelService } from '../services/channel.service.js';
 import { RoleService } from '../services/role.service.js';
-import {
-  buildScheduleModal,
-  parseScheduleFromModal,
-  prepareRatmasChannel,
-  publishWelcomeMessage,
-} from './ratmas-start.helpers.js';
+import { prepareRatmasChannel, publishWelcomeMessage } from './ratmas-start.helpers.js';
+import { parseRatmasSchedule } from '../utils/date.utils.js';
 
 export const RATMAS_COMMAND_NAME = 'ratmas';
-export const RATMAS_START_MODAL_ID = 'ratmas-start-schedule-modal';
 export const RATMAS_OPT_OUT_BUTTON_ID = 'ratmas-opt-out-button';
 
 const START_SUBCOMMAND = 'start';
@@ -88,60 +82,64 @@ export async function handleRatmasStartCommand(
     return;
   }
 
-  await interaction.showModal(buildScheduleModal(RATMAS_START_MODAL_ID));
-}
-
-export async function handleRatmasStartModal(
-  interaction: ModalSubmitInteraction,
-  deps: RatmasStartDependencies
-): Promise<void> {
-  if (interaction.customId !== RATMAS_START_MODAL_ID) return;
-
-  const guard = await validateInteraction(interaction, deps.ratService);
-  if (!guard.ok) {
-    await interaction.reply({
-      content: 'message' in guard ? guard.message : 'Error',
-      ephemeral: true,
-    });
-    return;
-  }
-
   try {
-    const schedule = parseScheduleFromModal(interaction);
-    const channelInfo = await prepareRatmasChannel({
-      client: interaction.client,
-      guildId: interaction.guildId!,
-      ratmasRoleId: guard.ratmasRoleId,
-      schedule,
-      channelService: deps.channelService,
-    });
-
-    await deps.ratService.createEvent({
-      guildId: interaction.guildId!,
-      ratmasRoleId: guard.ratmasRoleId,
-      eventStartDate: schedule.eventStartDate,
-      purchaseDeadline: schedule.purchaseDeadline,
-      revealDate: schedule.revealDate,
-      eventEndDate: schedule.eventEndDate,
-      announcementChannelId: channelInfo.channelId,
-    });
-
-    await publishWelcomeMessage({
-      client: interaction.client,
-      channelId: channelInfo.channelId,
-      schedule,
-      yearLabel: channelInfo.yearLabel,
-      optOutButtonId: RATMAS_OPT_OUT_BUTTON_ID,
-    });
-
-    await interaction.reply({
-      content: `Ratmas ${channelInfo.yearLabel} is live in <#${channelInfo.channelId}>!`,
-      ephemeral: true,
-    });
+    await executeRatmasStart(interaction, deps, guard.ratmasRoleId);
   } catch (error) {
     const message = error instanceof Error ? error.message : 'Failed to start Ratmas.';
     await interaction.reply({ content: message, ephemeral: true });
   }
+}
+
+async function executeRatmasStart(
+  interaction: ChatInputCommandInteraction,
+  deps: RatmasStartDependencies,
+  ratmasRoleId: string
+): Promise<void> {
+  // Parse dates from command options
+  const timezone = interaction.options.getString('timezone', true);
+  const startDate = interaction.options.getString('start_date', true);
+  const endDate = interaction.options.getString('end_date', true);
+  const revealDate = interaction.options.getString('reveal_date', true);
+  const purchaseDeadline = interaction.options.getString('purchase_deadline', true);
+
+  const schedule = parseRatmasSchedule({
+    startDate,
+    endDate,
+    revealDate,
+    purchaseDeadline,
+    timezone,
+  });
+
+  const channelInfo = await prepareRatmasChannel({
+    client: interaction.client,
+    guildId: interaction.guildId!,
+    ratmasRoleId,
+    schedule,
+    channelService: deps.channelService,
+  });
+
+  await deps.ratService.createEvent({
+    guildId: interaction.guildId!,
+    ratmasRoleId,
+    eventStartDate: schedule.eventStartDate,
+    purchaseDeadline: schedule.purchaseDeadline,
+    revealDate: schedule.revealDate,
+    eventEndDate: schedule.eventEndDate,
+    announcementChannelId: channelInfo.channelId,
+  });
+
+  await publishWelcomeMessage({
+    client: interaction.client,
+    channelId: channelInfo.channelId,
+    schedule,
+    yearLabel: channelInfo.yearLabel,
+    optOutButtonId: RATMAS_OPT_OUT_BUTTON_ID,
+  });
+
+  await interaction.reply({
+    content: `Ratmas ${channelInfo.yearLabel} is live in <#${channelInfo.channelId}>!`,
+    ephemeral: true,
+  });
 }
 
 export async function handleRatmasOptOutButton(
@@ -181,7 +179,7 @@ export async function handleRatmasOptOutButton(
 }
 
 async function validateInteraction(
-  interaction: ChatInputCommandInteraction | ModalSubmitInteraction,
+  interaction: ChatInputCommandInteraction,
   ratService: RatService
 ): Promise<{ ok: true; ratmasRoleId: string } | { ok: false; message: string }> {
   if (!interaction.guildId) {
@@ -214,7 +212,39 @@ async function validateInteraction(
 function buildStartSubcommand(
   subcommand: SlashCommandSubcommandBuilder
 ): SlashCommandSubcommandBuilder {
-  return subcommand.setName(START_SUBCOMMAND).setDescription("Start this year's Ratmas");
+  return subcommand
+    .setName(START_SUBCOMMAND)
+    .setDescription("Start this year's Ratmas")
+    .addStringOption((option) =>
+      option
+        .setName('timezone')
+        .setDescription('Your timezone (e.g., America/New_York, Europe/London, UTC)')
+        .setRequired(true)
+    )
+    .addStringOption((option) =>
+      option
+        .setName('start_date')
+        .setDescription('Start date (YYYY-MM-DD in your timezone)')
+        .setRequired(true)
+    )
+    .addStringOption((option) =>
+      option
+        .setName('end_date')
+        .setDescription('End date (YYYY-MM-DD in your timezone)')
+        .setRequired(true)
+    )
+    .addStringOption((option) =>
+      option
+        .setName('reveal_date')
+        .setDescription('Opening day (YYYY-MM-DD in your timezone)')
+        .setRequired(true)
+    )
+    .addStringOption((option) =>
+      option
+        .setName('purchase_deadline')
+        .setDescription('Purchase deadline (YYYY-MM-DD in your timezone)')
+        .setRequired(true)
+    );
 }
 
 function buildEndSubcommand(

--- a/src/commands/ratmas-start.helpers.ts
+++ b/src/commands/ratmas-start.helpers.ts
@@ -4,76 +4,15 @@ import {
   ButtonStyle,
   ChannelType,
   Client,
-  ModalBuilder,
-  ModalSubmitInteraction,
   TextChannel,
-  TextInputBuilder,
-  TextInputStyle,
 } from 'discord.js';
 import { DateTime } from 'luxon';
 import { ChannelService } from '../services/channel.service.js';
 import {
   RatmasSchedule,
-  parseRatmasSchedule,
   toDiscordTimestamp,
   calculateAssignmentAnnouncementDate,
 } from '../utils/date.utils.js';
-
-export const ScheduleFieldIds = {
-  startDate: 'ratmas-start-date',
-  endDate: 'ratmas-end-date',
-  revealDate: 'ratmas-reveal-date',
-  purchaseDeadline: 'ratmas-purchase-deadline',
-} as const;
-
-export function buildScheduleModal(modalId: string): ModalBuilder {
-  const modal = new ModalBuilder().setCustomId(modalId).setTitle('Ratmas Schedule (UTC)');
-
-  const fields = [
-    new TextInputBuilder()
-      .setCustomId(ScheduleFieldIds.startDate)
-      .setLabel('Start date (YYYY-MM-DD) UTC')
-      .setStyle(TextInputStyle.Short)
-      .setPlaceholder('e.g., 2025-12-01')
-      .setRequired(true),
-    new TextInputBuilder()
-      .setCustomId(ScheduleFieldIds.endDate)
-      .setLabel('End date (YYYY-MM-DD) UTC')
-      .setStyle(TextInputStyle.Short)
-      .setPlaceholder('e.g., 2025-12-26')
-      .setRequired(true),
-    new TextInputBuilder()
-      .setCustomId(ScheduleFieldIds.revealDate)
-      .setLabel('Opening day (YYYY-MM-DD) UTC')
-      .setStyle(TextInputStyle.Short)
-      .setPlaceholder('e.g., 2025-12-26')
-      .setRequired(true),
-    new TextInputBuilder()
-      .setCustomId(ScheduleFieldIds.purchaseDeadline)
-      .setLabel('Purchase deadline (YYYY-MM-DD) UTC')
-      .setStyle(TextInputStyle.Short)
-      .setPlaceholder('e.g., 2025-12-16')
-      .setRequired(true),
-  ];
-
-  modal.addComponents(
-    new ActionRowBuilder<TextInputBuilder>().addComponents(fields[0]!),
-    new ActionRowBuilder<TextInputBuilder>().addComponents(fields[1]!),
-    new ActionRowBuilder<TextInputBuilder>().addComponents(fields[2]!),
-    new ActionRowBuilder<TextInputBuilder>().addComponents(fields[3]!)
-  );
-
-  return modal;
-}
-
-export function parseScheduleFromModal(interaction: ModalSubmitInteraction): RatmasSchedule {
-  return parseRatmasSchedule({
-    startDate: interaction.fields.getTextInputValue(ScheduleFieldIds.startDate),
-    endDate: interaction.fields.getTextInputValue(ScheduleFieldIds.endDate),
-    revealDate: interaction.fields.getTextInputValue(ScheduleFieldIds.revealDate),
-    purchaseDeadline: interaction.fields.getTextInputValue(ScheduleFieldIds.purchaseDeadline),
-  });
-}
 
 export async function prepareRatmasChannel(params: {
   client: Client;

--- a/src/index.ts
+++ b/src/index.ts
@@ -8,7 +8,6 @@ import { RatService } from './services/rat.service.js';
 import {
   ensureRatmasStartCommand,
   handleRatmasStartCommand,
-  handleRatmasStartModal,
   handleRatmasOptOutButton,
 } from './commands/ratmas-start.command.js';
 import { handleRatmasEndCommand } from './commands/ratmas-end.command.js';
@@ -134,7 +133,6 @@ function registerInteractionHandlers(client: Client, services: AppServices): voi
         await handleWishlistCommand(interaction);
         await handlePairingsCommand(interaction, services.ratService);
       } else if (interaction.isModalSubmit()) {
-        await handleRatmasStartModal(interaction, ratmasDependencies);
         await handleWishlistModal(interaction, services.ratService);
       } else if (interaction.isButton()) {
         await handleRatmasOptOutButton(interaction, ratmasDependencies);

--- a/src/utils/date.utils.ts
+++ b/src/utils/date.utils.ts
@@ -30,10 +30,11 @@ export function toDiscordTimestamp(
 }
 
 export function parseRatmasSchedule(input: RatmasScheduleInput): RatmasSchedule {
-  const timezone = input.timezone || 'utc';
+  const timezone = input.timezone || 'UTC';
   
   // Validate timezone
-  if (!DateTime.local().setZone(timezone).isValid) {
+  const testDateTime = DateTime.now().setZone(timezone);
+  if (!testDateTime.isValid || testDateTime.invalidReason) {
     throw new Error(`Invalid timezone: ${timezone}. Please use a valid IANA timezone (e.g., America/New_York, Europe/London, UTC).`);
   }
 

--- a/src/utils/date.utils.ts
+++ b/src/utils/date.utils.ts
@@ -5,6 +5,7 @@ export interface RatmasScheduleInput {
   endDate: string;
   revealDate: string;
   purchaseDeadline: string;
+  timezone?: string;
 }
 
 export interface RatmasSchedule {
@@ -29,10 +30,17 @@ export function toDiscordTimestamp(
 }
 
 export function parseRatmasSchedule(input: RatmasScheduleInput): RatmasSchedule {
-  const eventStart = parseDateFieldUTC(input.startDate, 'Start date', 'start');
-  const eventEnd = parseDateFieldUTC(input.endDate, 'End date', 'end');
-  const reveal = parseDateFieldUTC(input.revealDate, 'Opening day', 'start');
-  const purchaseDeadline = parseDateFieldUTC(input.purchaseDeadline, 'Purchase deadline', 'end');
+  const timezone = input.timezone || 'utc';
+  
+  // Validate timezone
+  if (!DateTime.local().setZone(timezone).isValid) {
+    throw new Error(`Invalid timezone: ${timezone}. Please use a valid IANA timezone (e.g., America/New_York, Europe/London, UTC).`);
+  }
+
+  const eventStart = parseDateField(input.startDate, 'Start date', 'start', timezone);
+  const eventEnd = parseDateField(input.endDate, 'End date', 'end', timezone);
+  const reveal = parseDateField(input.revealDate, 'Opening day', 'start', timezone);
+  const purchaseDeadline = parseDateField(input.purchaseDeadline, 'Purchase deadline', 'end', timezone);
 
   return {
     eventStartDate: eventStart.toJSDate(),
@@ -48,16 +56,19 @@ export function calculateAssignmentAnnouncementDate(eventStartDate: Date): strin
   return toDiscordTimestamp(assignmentDate.toJSDate(), 'D');
 }
 
-function parseDateFieldUTC(value: string, label: string, boundary: 'start' | 'end'): DateTime {
+function parseDateField(value: string, label: string, boundary: 'start' | 'end', timezone: string): DateTime {
   const trimmed = value.trim();
   if (!trimmed) {
     throw new Error(`${label} is required.`);
   }
 
-  const parsed = DateTime.fromISO(trimmed, { zone: 'utc' });
+  // Parse in the user's timezone, then convert to UTC
+  const parsed = DateTime.fromISO(trimmed, { zone: timezone });
   if (!parsed.isValid) {
     throw new Error(`${label} must be in YYYY-MM-DD format.`);
   }
 
-  return boundary === 'end' ? parsed.endOf('day') : parsed.startOf('day');
+  // Apply boundary (start or end of day) in user's timezone, then convert to UTC
+  const withBoundary = boundary === 'end' ? parsed.endOf('day') : parsed.startOf('day');
+  return withBoundary.toUTC();
 }

--- a/src/utils/date.utils.ts
+++ b/src/utils/date.utils.ts
@@ -31,17 +31,24 @@ export function toDiscordTimestamp(
 
 export function parseRatmasSchedule(input: RatmasScheduleInput): RatmasSchedule {
   const timezone = input.timezone || 'UTC';
-  
+
   // Validate timezone
   const testDateTime = DateTime.now().setZone(timezone);
   if (!testDateTime.isValid || testDateTime.invalidReason) {
-    throw new Error(`Invalid timezone: ${timezone}. Please use a valid IANA timezone (e.g., America/New_York, Europe/London, UTC).`);
+    throw new Error(
+      `Invalid timezone: ${timezone}. Please use a valid IANA timezone (e.g., America/New_York, Europe/London, UTC).`
+    );
   }
 
   const eventStart = parseDateField(input.startDate, 'Start date', 'start', timezone);
   const eventEnd = parseDateField(input.endDate, 'End date', 'end', timezone);
   const reveal = parseDateField(input.revealDate, 'Opening day', 'start', timezone);
-  const purchaseDeadline = parseDateField(input.purchaseDeadline, 'Purchase deadline', 'end', timezone);
+  const purchaseDeadline = parseDateField(
+    input.purchaseDeadline,
+    'Purchase deadline',
+    'end',
+    timezone
+  );
 
   return {
     eventStartDate: eventStart.toJSDate(),
@@ -57,7 +64,12 @@ export function calculateAssignmentAnnouncementDate(eventStartDate: Date): strin
   return toDiscordTimestamp(assignmentDate.toJSDate(), 'D');
 }
 
-function parseDateField(value: string, label: string, boundary: 'start' | 'end', timezone: string): DateTime {
+function parseDateField(
+  value: string,
+  label: string,
+  boundary: 'start' | 'end',
+  timezone: string
+): DateTime {
   const trimmed = value.trim();
   if (!trimmed) {
     throw new Error(`${label} is required.`);


### PR DESCRIPTION
## Summary

This PR replaces the modal-based date input flow with direct slash command options and adds timezone support, allowing users to input dates in their local timezone which are automatically converted to UTC.

## Changes

### User-Facing Changes
- `/ratmas start` now accepts date parameters directly instead of showing a modal
- Added `timezone` parameter (e.g., `America/New_York`, `Europe/London`, `UTC`)
- Users can now enter dates in their local timezone using `YYYY-MM-DD` format
- All date fields updated to indicate "in your timezone" instead of requiring UTC

### Technical Changes
- **Removed**: Modal-based flow (`buildScheduleModal`, `parseScheduleFromModal`, `handleRatmasStartModal`)
- **Added**: Timezone parameter to slash command options
- **Updated**: `parseRatmasSchedule` to accept optional timezone and convert to UTC
- **Updated**: Date parsing to handle timezone conversion using Luxon
- **Refactored**: `handleRatmasStartCommand` to stay under 50-line lint limit
- **Added**: Timezone validation with clear error messages

### Command Structure
```
/ratmas start
  timezone: (required) Your timezone (e.g., America/New_York)
  start_date: (required) Start date (YYYY-MM-DD in your timezone)
  end_date: (required) End date (YYYY-MM-DD in your timezone)
  reveal_date: (required) Opening day (YYYY-MM-DD in your timezone)
  purchase_deadline: (required) Purchase deadline (YYYY-MM-DD in your timezone)
```

## Testing
- ✅ All 69 tests pass
- ✅ Added timezone conversion tests (America/New_York example)
- ✅ Added invalid timezone validation test
- ✅ Added default UTC behavior test
- ✅ TypeScript compiles without errors

## Example Usage
```
/ratmas start 
  timezone: America/New_York
  start_date: 2025-12-01
  end_date: 2025-12-26
  reveal_date: 2025-12-26
  purchase_deadline: 2025-12-16
```

The bot will convert all dates from EST/EDT to UTC automatically.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Timezone-aware Ratmas scheduling: accept timezones, default to UTC, and convert times to UTC for events.

* **Bug Fixes**
  * Ratmas start flow now accepts scheduling fields directly via the start command (no modal), keeping channel/event creation and welcome messages intact.
  * Invalid timezone input now returns a clear error.

* **Tests**
  * Updated tests to cover timezone parsing and the new inline start command behavior.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->