### PR TITLE
Add reset-assignment command for fixing incorrect rat selections

### DIFF
--- a/src/commands/admin_commands.py
+++ b/src/commands/admin_commands.py
@@ -403,3 +403,85 @@ async def setup_admin_commands(bot, db: "RatmasDB"):
         logger.info(
             f"Package update query initiated by {interaction.user.name}: {success_count} sent"
         )
+
+    @bot.tree.command(
+        name="reset-assignment",
+        description="[ADMIN] Reset a user's rat assignment (debug/fix option)",
+    )
+    @app_commands.describe(user="The user whose assignment to reset")
+    @app_commands.default_permissions(administrator=True)
+    async def reset_assignment(interaction: discord.Interaction, user: discord.Member):
+        """Reset a user's official rat assignment."""
+        await interaction.response.defer(ephemeral=True)
+
+        # Check if season is active
+        if not db.is_season_active():
+            await interaction.followup.send(
+                "❌ **No active season!**\n\nStart a season with `/start-ratmas` first.",
+                ephemeral=True,
+            )
+            return
+
+        # Check if user is a participant
+        user_data = db.get_user(user.id)
+        if not user_data:
+            await interaction.followup.send(
+                f"❌ **{user.display_name} is not a participant!**\n\n"
+                "They need to have the participant role to be in the exchange.",
+                ephemeral=True,
+            )
+            return
+
+        # Reset the assignment
+        reset_info = db.reset_user_assignment(user.id)
+
+        if not reset_info:
+            await interaction.followup.send(
+                f"❌ **{user.display_name} has no official assignment to reset.**\n\n"
+                "They either haven't selected a rat yet, or their assignment was already reset.",
+                ephemeral=True,
+            )
+            return
+
+        # Get receiver info
+        receiver_data = db.get_user(reset_info["receiver_id"])
+        receiver_name = receiver_data["display_name"] if receiver_data else "Unknown"
+        packages_count = reset_info["packages_count"]
+
+        # Build message
+        message = f"✅ **Assignment reset for {user.display_name}**\n\n"
+        message += f"Previous assignment: **{receiver_name}**\n"
+
+        if packages_count > 0:
+            message += f"Package count ({packages_count}) preserved as rogue assignment.\n\n"
+        else:
+            message += "No packages were recorded.\n\n"
+
+        message += (
+            f"**Next steps:**\n"
+            f"1. {user.mention} will need to reselect their rat using `/custom-assignments`\n"
+            f"2. Or you can notify them manually to check their DMs for the assignment selector"
+        )
+
+        await interaction.followup.send(message, ephemeral=True)
+        logger.info(
+            f"Assignment reset for {user.display_name} (was sending to {receiver_name}) by {interaction.user.name}"
+        )
+
+        # Notify the user and send new assignment selector
+        try:
+            # Send assignment selector DM
+            from ..handlers.assignment_handler import send_assignment_dm
+
+            await send_assignment_dm(bot, db, user)
+
+            await interaction.channel.send(
+                f"✅ Sent new assignment selector to {user.mention}", delete_after=10
+            )
+        except Exception as e:
+            logger.error(f"Failed to send new assignment selector to {user.display_name}: {e}")
+            await interaction.channel.send(
+                f"⚠️ Failed to send new assignment selector to {user.mention}. "
+                "You may need to run `/custom-assignments` again.",
+                delete_after=15,
+            )

--- a/src/database.py
+++ b/src/database.py
@@ -195,3 +195,33 @@ class RatmasDB:
                 total += assignment.get("packages_count", 0)
 
         return total
+
+    # Assignment Reset
+
+    def reset_user_assignment(self, user_id: int) -> Optional[Dict]:
+        """Reset a user's official assignment, preserving package counts as rogue.
+
+        Args:
+            user_id: User whose assignment to reset
+
+        Returns:
+            Info about the reset assignment, or None if no assignment found
+        """
+        # Get user's official assignment
+        assignment = self.get_official_assignment(user_id)
+        if not assignment:
+            return None
+
+        receiver_id = assignment["receiver_id"]
+        packages_count = assignment.get("packages_count", 0)
+
+        # Remove the official assignment
+        self.remove_assignment(user_id, receiver_id)
+
+        # If there were packages, preserve as non-official (rogue) assignment
+        if packages_count > 0:
+            self.add_assignment(
+                user_id, receiver_id, is_official=False, packages_count=packages_count
+            )
+
+        return {"receiver_id": receiver_id, "packages_count": packages_count}


### PR DESCRIPTION
## Summary

This PR adds a new admin command `/reset-assignment` to handle cases where users select their rat assignment incorrectly, providing a way to recover from bad states without resetting the entire exchange.

### Problem Solved

Sometimes users accidentally select the wrong person as their gift recipient. Previously, the only option was to:
- End the entire exchange with `/end-ratmas` and start over ❌
- Manually coordinate reassignments ❌

This command provides a simple admin tool to reset a single user's assignment while preserving their progress.

## Features

- **Admin command**: `/reset-assignment @user` - Resets a specific user's assignment
- **Preserves package data**: Package counts are converted to rogue assignments (not lost)
- **Automatic re-selection**: User immediately receives a new assignment selector DM
- **Audit trail**: All resets are logged with details about the previous assignment
- **Safety checks**: Validates user is a participant before resetting

## Usage

```
/reset-assignment @JohnDoe
```

The command will:
1. Remove John's current official assignment (e.g., sending to Jane)
2. If John had entered package counts, preserve them as a "rogue" assignment to Jane
3. Send John a new DM with the assignment selector to choose again
4. Notify the admin: "Assignment reset for JohnDoe. Previous assignment: Jane. Package count (2) preserved as rogue assignment."

## Technical Details

### Database Changes

Added `reset_user_assignment(user_id)` method to `database.py`:
- Fetches user's current official assignment
- Removes the official assignment
- Converts to non-official (rogue) assignment if packages were recorded
- Returns info about the reset for logging

### Command Implementation

In `admin_commands.py`, added `/reset-assignment` command that:
- Checks if season is active
- Validates user is a participant  
- Calls `reset_user_assignment()` to remove assignment
- Calls `send_assignment_dm()` to send new selector
- Reports results to admin

## Testing

Manual testing should verify:
- [ ] Command only works when season is active
- [ ] Command rejects non-participants  
- [ ] User's assignment is removed from database
- [ ] Package counts are preserved as rogue assignment
- [ ] User receives new assignment selector DM
- [ ] Admin sees confirmation with previous assignment details
- [ ] User can successfully select a new recipient

## Notes

- This is a debug/fix option for handling edge cases
- Package counts are preserved to avoid data loss
- Users can immediately re-select their recipient after reset
- All operations are logged for audit purposes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new admin command to reset user rat assignments with built-in validation and error handling.
  * Automated notifications sent to affected users with next-step guidance for reassignment.
  * Reset actions logged for administrative audit trail and monitoring.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->